### PR TITLE
Changes done after testing vol 1

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:lts-alpine
+FROM node:12-alpine3.12
 
 RUN apk update && apk add bash
 

--- a/src/auth/auth.resolver.spec.ts
+++ b/src/auth/auth.resolver.spec.ts
@@ -8,7 +8,6 @@ import { AuthResolver } from './auth.resolver';
 import { UserRepository } from '../users/repositories/user.repository';
 import { UsersService } from '../users/users.service';
 import { JwtStrategy } from './strategies/jwt.strategy';
-import { UsersModule } from '../users/users.module';
 import { getModelToken } from '@nestjs/mongoose';
 
 describe('AuthResolver', () => {

--- a/src/challenge-status/challenge-status.resolver.ts
+++ b/src/challenge-status/challenge-status.resolver.ts
@@ -14,7 +14,6 @@ import { ChallengeDto } from '../challenge/dto/challenge.dto';
 import { Challenge } from '../challenge/models/challenge.model';
 import { ChallengeService } from '../challenge/challenge.service';
 import { ChallengeToDtoMapper } from '../challenge/mappers/challenge-to-dto.mapper';
-import { GqlEnrolledInGame } from '../common/guards/gql-game-enrollment.guard';
 import { GqlAdminGuard } from '../common/guards/gql-admin.guard';
 
 @Resolver(() => ChallengeStatusDto)

--- a/src/challenge-status/challenge-status.service.ts
+++ b/src/challenge-status/challenge-status.service.ts
@@ -6,7 +6,6 @@ import { TriggerEventEnum as TriggerEvent } from '../hook/enums/trigger-event.en
 import { ChallengeStatus } from './models/challenge-status.model';
 import { StateEnum } from './models/state.enum';
 import { ChallengeStatusRepository } from './repositories/challenge-status.repository';
-import { toString } from '../common/utils/mongo.utils';
 
 @Injectable()
 export class ChallengeStatusService extends BaseService<ChallengeStatus> {

--- a/src/challenge-status/challenge-status.service.ts
+++ b/src/challenge-status/challenge-status.service.ts
@@ -84,8 +84,8 @@ export class ChallengeStatusService extends BaseService<ChallengeStatus> {
    */
   async markAsCompleted(gameId: string, challengeId: string, playerId: string, date: Date): Promise<ChallengeStatus> {
     const temp: ChallengeStatus = await this.findByChallengeIdAndPlayerId(challengeId, playerId);
-    if (temp.state === StateEnum.COMPLETED) {
-      console.log('challenge already completed');
+    if (temp.state === StateEnum.COMPLETED || temp.state === StateEnum.HIDDEN || temp.state === StateEnum.LOCKED) {
+      console.log('challenge already completed or locked');
       return;
     }
     const result: ChallengeStatus = await this.patch(temp.id, { state: StateEnum.COMPLETED, endedAt: date });

--- a/src/challenge-status/challenge-status.service.ts
+++ b/src/challenge-status/challenge-status.service.ts
@@ -85,6 +85,10 @@ export class ChallengeStatusService extends BaseService<ChallengeStatus> {
    */
   async markAsCompleted(gameId: string, challengeId: string, playerId: string, date: Date): Promise<ChallengeStatus> {
     const temp: ChallengeStatus = await this.findByChallengeIdAndPlayerId(challengeId, playerId);
+    if (temp.state === StateEnum.COMPLETED) {
+      console.log('challenge already completed');
+      return;
+    }
     const result: ChallengeStatus = await this.patch(temp.id, { state: StateEnum.COMPLETED, endedAt: date });
 
     // send CHALLENGE_COMPLETED message to execute attached hooks

--- a/src/common/helpers/criteria.helper.ts
+++ b/src/common/helpers/criteria.helper.ts
@@ -22,9 +22,6 @@ export async function checkCriteria(
     return result;
   } else {
     const conditions = [...criteria.conditions].sort((a, b) => (a.order > b.order ? 1 : -1));
-    console.log(criteria);
-    console.log(actionObj);
-    console.log(params);
     let i = 0;
     do {
       const condition = conditions[i];

--- a/src/common/helpers/pagination.helper.ts
+++ b/src/common/helpers/pagination.helper.ts
@@ -8,6 +8,8 @@ import { IPageQueryResult } from '../interfaces/page-query-result.interface copy
 import { IPage } from '../interfaces/page.interface';
 import { isNumber } from '../utils/type-checking.utils';
 
+/* eslint-disable */
+
 /**
  * Retrieve the Sort Order.
  *

--- a/src/common/helpers/service.helper.ts
+++ b/src/common/helpers/service.helper.ts
@@ -2,8 +2,6 @@ import { Injectable } from '@nestjs/common';
 
 import { IWhereName } from '../interfaces/where-name.interface';
 import { IWhereIds } from '../interfaces/where-ids.interface';
-import { findOrder } from '../types/find-order.type';
-import { FindNameDto } from '../dto/find-name.dto';
 import { toMongoId } from '../utils/mongo.utils';
 import { IRepository } from '../interfaces/repository.interface';
 

--- a/src/common/utils/tree.utils.ts
+++ b/src/common/utils/tree.utils.ts
@@ -12,6 +12,7 @@ export function createTree(array: any[], key = 'id', parentKey = 'parentId', chi
   return tree;
 }
 
+/* eslint-disable-next-line */
 export function findSubtree(tree: any[], lookup: any, key = 'id', childrenProp = 'children'): any {
   if (!tree || tree.length === 0) {
     return undefined;

--- a/src/evaluation-engine/evaluation-engine.listener.ts
+++ b/src/evaluation-engine/evaluation-engine.listener.ts
@@ -11,6 +11,7 @@ export class EvaluationEngineListener {
   constructor(@InjectQueue(appConfig.queue.evaluation.name) protected readonly evaluationQueue: Queue) {}
 
   @OnGlobalQueueCompleted()
+  /* eslint-disable-next-line */
   async onGlobalCompleted(jobId: number, result: any): Promise<void> {
     const job = await this.evaluationQueue.getJob(jobId);
     this.logger.debug(`(Global) on completed: job ${job.id} -> result: ${result}`);

--- a/src/event/event.listener.ts
+++ b/src/event/event.listener.ts
@@ -11,6 +11,7 @@ export class EventListener {
   constructor(@InjectQueue(appConfig.queue.event.name) protected readonly eventQueue: Queue) {}
 
   @OnGlobalQueueCompleted()
+  /* eslint-disable-next-line */
   async onGlobalCompleted(jobId: number, result: any): Promise<void> {
     const job = await this.eventQueue.getJob(jobId);
     this.logger.debug(`(Global) on completed: job ${job.id} - ${job.name} -> result: ${result}`);

--- a/src/event/processors/challenge.processor.ts
+++ b/src/event/processors/challenge.processor.ts
@@ -3,13 +3,11 @@ import { Job } from 'bull';
 
 import { appConfig } from 'src/app.config';
 import { ChallengeStatusService } from 'src/challenge-status/challenge-status.service';
-import { ChallengeStatus } from 'src/challenge-status/models/challenge-status.model';
 import { ChallengeService } from 'src/challenge/challenge.service';
 import { Challenge } from 'src/challenge/models/challenge.model';
 import { ActionHookService } from 'src/hook/action-hook.service';
 import { TriggerEventEnum as TriggerEvent } from 'src/hook/enums/trigger-event.enum';
 import { HookService } from 'src/hook/hook.service';
-import { StateEnum as State } from '../../challenge-status/models/state.enum';
 
 @Processor(appConfig.queue.event.name)
 export class ChallengeProcessor {
@@ -45,6 +43,74 @@ export class ChallengeProcessor {
     const actionHooks = await this.actionHookService.findAll({
       game: { $eq: gameId },
       trigger: TriggerEvent.CHALLENGE_OPENED,
+      sourceId: challengeId,
+    });
+
+    for (const actionHook of actionHooks) {
+      await this.hookService.executeHook(actionHook, job.data, { ...challenge });
+    }
+  }
+
+  @Process(`${TriggerEvent.CHALLENGE_REJECTED}_JOB`)
+  async onChallengeRejected(job: Job<{ gameId: string; challengeId: string; playerId: string }>): Promise<void> {
+    const { gameId, challengeId, playerId } = job.data;
+    const challenge: Challenge = await this.challengeService.findById(challengeId);
+
+    //process hooks
+    const actionHooks = await this.actionHookService.findAll({
+      game: { $eq: gameId },
+      trigger: TriggerEvent.CHALLENGE_REJECTED,
+      sourceId: challengeId,
+    });
+
+    for (const actionHook of actionHooks) {
+      await this.hookService.executeHook(actionHook, job.data, { ...challenge });
+    }
+  }
+
+  @Process(`${TriggerEvent.CHALLENGE_FAILED}_JOB`)
+  async onChallengeFailed(job: Job<{ gameId: string; challengeId: string; playerId: string }>): Promise<void> {
+    const { gameId, challengeId, playerId } = job.data;
+    const challenge: Challenge = await this.challengeService.findById(challengeId);
+
+    //process hooks
+    const actionHooks = await this.actionHookService.findAll({
+      game: { $eq: gameId },
+      trigger: TriggerEvent.CHALLENGE_FAILED,
+      sourceId: challengeId,
+    });
+
+    for (const actionHook of actionHooks) {
+      await this.hookService.executeHook(actionHook, job.data, { ...challenge });
+    }
+  }
+
+  @Process(`${TriggerEvent.CHALLENGE_HIDDEN}_JOB`)
+  async onChallengeHidden(job: Job<{ gameId: string; challengeId: string; playerId: string }>): Promise<void> {
+    const { gameId, challengeId, playerId } = job.data;
+    const challenge: Challenge = await this.challengeService.findById(challengeId);
+
+    //process hooks
+    const actionHooks = await this.actionHookService.findAll({
+      game: { $eq: gameId },
+      trigger: TriggerEvent.CHALLENGE_HIDDEN,
+      sourceId: challengeId,
+    });
+
+    for (const actionHook of actionHooks) {
+      await this.hookService.executeHook(actionHook, job.data, { ...challenge });
+    }
+  }
+
+  @Process(`${TriggerEvent.CHALLENGE_AVAILABLE}_JOB`)
+  async onChallengeAvailable(job: Job<{ gameId: string; challengeId: string; playerId: string }>): Promise<void> {
+    const { gameId, challengeId, playerId } = job.data;
+    const challenge: Challenge = await this.challengeService.findById(challengeId);
+
+    //process hooks
+    const actionHooks = await this.actionHookService.findAll({
+      game: { $eq: gameId },
+      trigger: TriggerEvent.CHALLENGE_AVAILABLE,
       sourceId: challengeId,
     });
 

--- a/src/event/processors/challenge.processor.ts
+++ b/src/event/processors/challenge.processor.ts
@@ -2,11 +2,14 @@ import { Process, Processor } from '@nestjs/bull';
 import { Job } from 'bull';
 
 import { appConfig } from 'src/app.config';
+import { ChallengeStatusService } from 'src/challenge-status/challenge-status.service';
+import { ChallengeStatus } from 'src/challenge-status/models/challenge-status.model';
 import { ChallengeService } from 'src/challenge/challenge.service';
 import { Challenge } from 'src/challenge/models/challenge.model';
 import { ActionHookService } from 'src/hook/action-hook.service';
 import { TriggerEventEnum as TriggerEvent } from 'src/hook/enums/trigger-event.enum';
 import { HookService } from 'src/hook/hook.service';
+import { StateEnum as State } from '../../challenge-status/models/state.enum';
 
 @Processor(appConfig.queue.event.name)
 export class ChallengeProcessor {
@@ -14,17 +17,34 @@ export class ChallengeProcessor {
     protected readonly actionHookService: ActionHookService,
     protected readonly hookService: HookService,
     protected readonly challengeService: ChallengeService,
+    protected readonly challengeStatusService: ChallengeStatusService,
   ) {}
 
   @Process(`${TriggerEvent.CHALLENGE_COMPLETED}_JOB`)
   async onChallengeCompleted(job: Job<{ gameId: string; challengeId: string; playerId: string }>): Promise<void> {
     const { gameId, challengeId, playerId } = job.data;
     const challenge: Challenge = await this.challengeService.findById(challengeId);
-
     //process hooks
     const actionHooks = await this.actionHookService.findAll({
       game: { $eq: gameId },
       trigger: TriggerEvent.CHALLENGE_COMPLETED,
+      sourceId: challengeId,
+    });
+
+    for (const actionHook of actionHooks) {
+      await this.hookService.executeHook(actionHook, job.data, { ...challenge });
+    }
+  }
+
+  @Process(`${TriggerEvent.CHALLENGE_OPENED}_JOB`)
+  async onChallengeOpened(job: Job<{ gameId: string; challengeId: string; playerId: string }>): Promise<void> {
+    const { gameId, challengeId, playerId } = job.data;
+    const challenge: Challenge = await this.challengeService.findById(challengeId);
+
+    //process hooks
+    const actionHooks = await this.actionHookService.findAll({
+      game: { $eq: gameId },
+      trigger: TriggerEvent.CHALLENGE_OPENED,
       sourceId: challengeId,
     });
 

--- a/src/event/processors/reward.processor.ts
+++ b/src/event/processors/reward.processor.ts
@@ -2,9 +2,6 @@ import { Process, Processor } from '@nestjs/bull';
 import { Job } from 'bull';
 
 import { appConfig } from '../../app.config';
-import { PlayerService } from '../../player/player.service';
-import { ChallengeService } from '../../challenge/challenge.service';
-import { EventService } from '../event.service';
 import { HookService } from '../../hook/hook.service';
 import { ActionHookService } from '../../hook/action-hook.service';
 import { RewardService } from '../../reward/reward.service';

--- a/src/event/processors/submission.processor.ts
+++ b/src/event/processors/submission.processor.ts
@@ -22,13 +22,17 @@ export class SubmissionProcessor {
   @Process(`${TriggerEvent.SUBMISSION_RECEIVED}_JOB`)
   async onSubmissionReceived(job: Job<{ gameId: string; exerciseId: string; playerId: string }>): Promise<void> {
     const { gameId, exerciseId, playerId } = job.data;
-
+    console.log('SUB RECEIVED');
     // process hooks
     const actionHooks = await this.actionHookService.findAll({
-      game: { $eq: gameId },
-      trigger: TriggerEvent.SUBMISSION_RECEIVED,
-      sourceId: exerciseId,
+      $and: [
+        { game: { $eq: gameId } },
+        { trigger: TriggerEvent.SUBMISSION_RECEIVED },
+        { $or: [{ sourceId: { $eq: exerciseId } }, { sourceId: { $eq: null } }] },
+      ],
     });
+
+    console.log(actionHooks);
 
     for (const actionHook of actionHooks) {
       await this.hookService.executeHook(actionHook, job.data, { exerciseId: exerciseId });

--- a/src/game/inputs/game.input.ts
+++ b/src/game/inputs/game.input.ts
@@ -1,6 +1,6 @@
 import { Field, InputType } from '@nestjs/graphql';
 import { Type } from 'class-transformer';
-import { MinLength, MaxLength, IsString, IsOptional, IsArray, IsDate, IsUUID } from 'class-validator';
+import { MinLength, MaxLength, IsString, IsOptional, IsDate, IsUUID } from 'class-validator';
 
 @InputType()
 export class GameInput {

--- a/src/game/mappers/game-to-dto.mapper.ts
+++ b/src/game/mappers/game-to-dto.mapper.ts
@@ -1,14 +1,8 @@
 import { Injectable } from '@nestjs/common';
-import { Types } from 'mongoose';
 
 import { IMapper } from '../../common/interfaces/mapper.interface';
-import { PlayerDto } from '../../player/dto/player.dto';
-import { PlayerToDtoMapper } from '../../player/mappers/player-to-dto.mapper';
-import { PlayerService } from '../../player/player.service';
-import { SubmissionDto } from '../../submission/dto/submission.dto';
 import { GameDto } from '../dto/game.dto';
 import { Game } from '../models/game.model';
-import { classToPlain, plainToClass } from 'class-transformer';
 import { pick } from '../../common/utils/object.utils';
 
 @Injectable()

--- a/src/game/models/game.model.ts
+++ b/src/game/models/game.model.ts
@@ -1,9 +1,6 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 
-import { Player } from '../../player/models/player.model';
-import { Submission } from '../../submission/models/submission.model';
-
 @Schema()
 export class Game extends Document {
   @Prop()

--- a/src/hook/hook.service.ts
+++ b/src/hook/hook.service.ts
@@ -53,20 +53,18 @@ export class HookService {
       for (const trigger of triggers) {
         let hook: ScheduledHook | ActionHook;
         let sourceIds;
-        if (trigger.parameters[0] && trigger.parameters[0] !== null) {
-          if (trigger.event.startsWith('CHALLENGE_')) {
-            sourceIds = trigger.parameters.map(gedilId => imported.challenges[gedilId]['_id'].toString());
-            trigger.parameters = sourceIds;
-          } else if (trigger.event.startsWith('REWARD_')) {
-            sourceIds = trigger.parameters.map(gedilId => imported.rewards[gedilId]['_id'].toString());
-            trigger.parameters = sourceIds;
-          }
-          if (encodedContent.actions[0].parameters && encodedContent.actions[0].parameters !== null) {
-            const mappedParameters = encodedContent.actions[0].parameters.map(gedilId =>
-              imported.rewards[gedilId]['_id'].toString(),
-            );
-            encodedContent.actions[0].parameters = mappedParameters;
-          }
+        if (trigger.event.startsWith('CHALLENGE_')) {
+          sourceIds = trigger.parameters.map(gedilId => imported.challenges[gedilId]['_id'].toString());
+          trigger.parameters = sourceIds;
+        } else if (trigger.event.startsWith('REWARD_')) {
+          sourceIds = trigger.parameters.map(gedilId => imported.rewards[gedilId]['_id'].toString());
+          trigger.parameters = sourceIds;
+        }
+        if (encodedContent.actions[0].parameters && encodedContent.actions[0].parameters !== null) {
+          const mappedParameters = encodedContent.actions[0].parameters.map(gedilId =>
+            imported.rewards[gedilId]['_id'].toString(),
+          );
+          encodedContent.actions[0].parameters = mappedParameters;
         }
 
         const data: { [key: string]: any } = {
@@ -199,7 +197,7 @@ export class HookService {
 
       if (playerReward && !reward.recurrent) {
         // player already has the reward and it is not accumulative
-        //return;
+        return;
       } else if (playerReward) {
         // player already has the reward and it is accumulative
         const quantity: number = playerReward.count + (parameters[1] ? +parameters[1] : 1);

--- a/src/hook/hook.service.ts
+++ b/src/hook/hook.service.ts
@@ -23,7 +23,6 @@ import { ConditionInput } from './inputs/condition.input';
 import { ScheduledHook } from './models/scheduled-hook.model';
 import { ActionHook } from './models/action-hook.model';
 import { ActionEmbed } from './models/embedded/action.embed';
-import { toString } from '../common/utils/mongo.utils';
 
 @Injectable()
 export class HookService {

--- a/src/leaderboard/dto/player-submissions.dto.ts
+++ b/src/leaderboard/dto/player-submissions.dto.ts
@@ -1,6 +1,4 @@
 import { Field, ObjectType } from '@nestjs/graphql';
-import graphqlTypeJson from 'graphql-type-json';
-import { Player } from 'src/player/models/player.model';
 import { Submission } from 'src/submission/models/submission.model';
 
 import { PlayerDto } from '../../player/dto/player.dto';

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,7 +5,10 @@ import * as cookieParser from 'cookie-parser';
 import { AppModule } from './app.module';
 import { appConfig } from './app.config';
 
+const EventEmitter = require('events'); /* eslint-disable-line */
+
 async function bootstrap() {
+  EventEmitter.defaultMaxListeners = 30;
   const app = await NestFactory.create(AppModule, { logger: appConfig.logger });
   app.use(helmet());
   app.use(cookieParser());

--- a/src/player-reward/player-reward.service.ts
+++ b/src/player-reward/player-reward.service.ts
@@ -1,14 +1,9 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { BaseService } from '../common/services/base.service';
-import { Player } from '../player/models/player.model';
-import { Reward } from '../reward/models/reward.model';
-import { RewardType } from '../reward/models/reward-type.enum';
 import { PlayerReward } from './models/player-reward.model';
 import { PlayerRewardRepository } from './repositories/player-reward.repository';
 import { PlayerRewardToDtoMapper } from './mappers/player-reward-to-dto.mapper';
-import { PlayerRewardDto } from './dto/player-reward.dto';
-import { PlayerDto } from 'src/player/dto/player.dto';
 
 @Injectable()
 export class PlayerRewardService extends BaseService<PlayerReward> {
@@ -17,18 +12,5 @@ export class PlayerRewardService extends BaseService<PlayerReward> {
     protected readonly toDtoMapper: PlayerRewardToDtoMapper,
   ) {
     super(new Logger(PlayerRewardService.name), repository);
-  }
-
-  async giveReward(rewardId: string, player: PlayerDto, count: number) {
-    this.repository.save({
-      player: player.id,
-      reward: rewardId,
-      count: count,
-    });
-  }
-
-  async ifEnoughForGranting(amount: string[]) {
-    //after REWARD_GRANNTED trigger
-    //to be implemented...
   }
 }

--- a/src/player/models/player.model.ts
+++ b/src/player/models/player.model.ts
@@ -1,6 +1,5 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
-import { Submission } from '../../submission/models/submission.model';
 
 @Schema()
 export class Player extends Document {

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -446,7 +446,7 @@ type Query {
 type Mutation {
   saveUser(id: ID, userInput: UserInput!): User!
   deleteUser(id: ID!): User!
-  evaluate(gameId: String!, exerciseId: String!, challengeId: String!, file: Upload!): Submission
+  evaluate(gameId: String!, exerciseId: String!, file: Upload!): Submission
   importGEdILArchive(gameInput: GameInput!, file: Upload!): Game!
   enroll(gameId: String!): Player!
   login(login: String!, password: String!): User!

--- a/src/schema.gql
+++ b/src/schema.gql
@@ -446,7 +446,7 @@ type Query {
 type Mutation {
   saveUser(id: ID, userInput: UserInput!): User!
   deleteUser(id: ID!): User!
-  evaluate(gameId: String!, exerciseId: String!, file: Upload!): Submission!
+  evaluate(gameId: String!, exerciseId: String!, challengeId: String!, file: Upload!): Submission
   importGEdILArchive(gameInput: GameInput!, file: Upload!): Game!
   enroll(gameId: String!): Player!
   login(login: String!, password: String!): User!

--- a/src/submission/args/evaluate.args.ts
+++ b/src/submission/args/evaluate.args.ts
@@ -11,9 +11,6 @@ export class EvaluateArgs {
   @Field()
   exerciseId: string;
 
-  @Field()
-  challengeId: string;
-
   @Field(() => GraphQLUpload)
   @IsDefined()
   file: Promise<FileUpload>;

--- a/src/submission/args/evaluate.args.ts
+++ b/src/submission/args/evaluate.args.ts
@@ -11,6 +11,9 @@ export class EvaluateArgs {
   @Field()
   exerciseId: string;
 
+  @Field()
+  challengeId: string;
+
   @Field(() => GraphQLUpload)
   @IsDefined()
   file: Promise<FileUpload>;

--- a/src/submission/submission.module.ts
+++ b/src/submission/submission.module.ts
@@ -11,6 +11,7 @@ import { SubmissionResolver } from './submission.resolver';
 import { SubmissionRepository } from './repositories/submission.repository';
 import { Submission, SubmissionSchema } from './models/submission.model';
 import { SubmissionToDtoMapper } from './mappers/submission-to-dto.mapper';
+import { ChallengeStatusModule } from 'src/challenge-status/challenge-status.module';
 
 @Module({
   imports: [
@@ -25,6 +26,7 @@ import { SubmissionToDtoMapper } from './mappers/submission-to-dto.mapper';
     forwardRef(() => GameModule),
     forwardRef(() => PlayerModule),
     forwardRef(() => HookModule),
+    forwardRef(() => ChallengeStatusModule),
   ],
   providers: [SubmissionToDtoMapper, SubmissionRepository, SubmissionService, SubmissionResolver],
   exports: [SubmissionToDtoMapper, SubmissionService],

--- a/src/submission/submission.resolver.ts
+++ b/src/submission/submission.resolver.ts
@@ -58,17 +58,23 @@ export class SubmissionResolver {
     return Promise.all(submissions.map(async submission => this.submissionToDtoMapper.transform(submission)));
   }
 
-  @Mutation(() => SubmissionDto)
+  @Mutation(() => SubmissionDto, { nullable: true })
   @UseGuards(GqlJwtAuthGuard, GqlEnrolledInGame)
-  async evaluate(@GqlPlayer('id') playerId: string, @Args() args: EvaluateArgs): Promise<SubmissionDto> {
-    const { gameId, exerciseId, file } = args;
+  async evaluate(@GqlPlayer('id') playerId: string, @Args() args: EvaluateArgs): Promise<SubmissionDto> | null {
+    const { gameId, exerciseId, challengeId, file } = args;
     const { filename, encoding, mimetype, createReadStream } = await file;
-    const submission: Submission = await this.submissionService.sendSubmission(gameId, exerciseId, playerId, {
-      filename,
-      encoding: encoding as BufferEncoding,
-      mimetype,
-      content: await createReadStream(),
-    });
+    const submission: Submission = await this.submissionService.sendSubmission(
+      gameId,
+      exerciseId,
+      challengeId,
+      playerId,
+      {
+        filename,
+        encoding: encoding as BufferEncoding,
+        mimetype,
+        content: await createReadStream(),
+      },
+    );
     return this.submissionToDtoMapper.transform(submission);
   }
 

--- a/src/submission/submission.resolver.ts
+++ b/src/submission/submission.resolver.ts
@@ -60,21 +60,15 @@ export class SubmissionResolver {
 
   @Mutation(() => SubmissionDto, { nullable: true })
   @UseGuards(GqlJwtAuthGuard, GqlEnrolledInGame)
-  async evaluate(@GqlPlayer('id') playerId: string, @Args() args: EvaluateArgs): Promise<SubmissionDto> | null {
-    const { gameId, exerciseId, challengeId, file } = args;
+  async evaluate(@GqlPlayer('id') playerId: string, @Args() args: EvaluateArgs): Promise<SubmissionDto> {
+    const { gameId, exerciseId, file } = args;
     const { filename, encoding, mimetype, createReadStream } = await file;
-    const submission: Submission = await this.submissionService.sendSubmission(
-      gameId,
-      exerciseId,
-      challengeId,
-      playerId,
-      {
-        filename,
-        encoding: encoding as BufferEncoding,
-        mimetype,
-        content: await createReadStream(),
-      },
-    );
+    const submission: Submission = await this.submissionService.sendSubmission(gameId, exerciseId, playerId, {
+      filename,
+      encoding: encoding as BufferEncoding,
+      mimetype,
+      content: await createReadStream(),
+    });
     return this.submissionToDtoMapper.transform(submission);
   }
 

--- a/src/submission/submission.service.ts
+++ b/src/submission/submission.service.ts
@@ -35,34 +35,22 @@ export class SubmissionService extends BaseService<Submission> {
     return this.findAll(query);
   }
 
-  async sendSubmission(
-    gameId: string,
-    exerciseId: string,
-    challengeId: string,
-    playerId: string,
-    file: IFile,
-  ): Promise<Submission> {
-    const challengeStatus = await this.challengeStatusService.findByChallengeIdAndPlayerId(challengeId, playerId);
-    if (challengeStatus.state === State.LOCKED || challengeStatus.state === State.HIDDEN) {
-      console.log('Player did not unlock the challenge or its hidden...');
-      return;
-    } else {
-      const submission: Submission = await super.create({
-        game: gameId,
-        player: playerId,
-        exerciseId: exerciseId,
-      } as Submission);
+  async sendSubmission(gameId: string, exerciseId: string, playerId: string, file: IFile): Promise<Submission> {
+    const submission: Submission = await super.create({
+      game: gameId,
+      player: playerId,
+      exerciseId: exerciseId,
+    } as Submission);
 
-      // send SUBMISSION_RECEIVED event
-      await this.eventService.fireEvent(TriggerEvent.SUBMISSION_RECEIVED, {
-        gameId: gameId,
-        playerId: playerId,
-        exerciseId: exerciseId,
-      });
+    // send SUBMISSION_RECEIVED event
+    await this.eventService.fireEvent(TriggerEvent.SUBMISSION_RECEIVED, {
+      gameId: gameId,
+      playerId: playerId,
+      exerciseId: exerciseId,
+    });
 
-      await this.evaluationEngineService.evaluate(submission.id, file);
+    await this.evaluationEngineService.evaluate(submission.id, file);
 
-      return submission;
-    }
+    return submission;
   }
 }


### PR DESCRIPTION
### 16/11/2020

**What I've done so far:**
1. 1 game, 1 user, all challenges completion - **passed**
2. 1 game, 2+ users, all challenges completion - **passed**, fixed resubmitting challenges if already completed
3. +20 submission reward - **not passed** and I could not map the place where the issue originates from, console.logs were printing the translated id but in the repo it was still the gedil id and resulted in errors during rewards assignment
4. Check CHALLENGE_OPENED job - **done**, I will implement the complete section of CHALLENGE_*** hooks in the next commit

**What I've noticed/changed:**
- no metrics in submissions not updated in Moshaak (not sure if its an issue or just a detail that we do not need for now)
- submission language not updated in Moshaak (not sure if its an issue or just a detail that we do not need for now)
- fixed resubmitting (could result in reopening of rewarded/unlocked challenge) (submission.processor.ts)
- second reward (20+ submissions) is not being assigned

### 
17/11/2020
**What I've done so far:**
1. 3 games, 1 user, all challenges completion (pay attention to the hooks) - **passed**
2. The same user enrolled in 3 different games (check rewards assignments, ids of game, player and submissions) - **passed**
3. Check the same user in 3 games, if they do not overlap somehow or mix - **passed**
4. 2 users enrolled in 3 diff games (check rewards assignments, ids of game, player and submissions)  - **passed**

**What I've noticed/changed:**
- Locked challenge D could have been completed without unlocking it first (therefore additional `challenge` in EvaluationArgs in `evaluate` Mutation), should secure it also for FAILED, REJECTED?
- @Mutation(() => SubmissionDto, { **nullable: true** }) evaluate - because if the challenge is locked/hidden we return null, without {nullable: true} it was complaining...
- Implemented CHALLENGE_*** jobs
-  `(node:332) MaxListenersExceededWarning: Possible EventEmitter memory leak detected. 11 error listeners added to [Redis]. Use emitter.setMaxListeners() to increase limit` - error appearing in the console after creating all CHALLENGE_*** processors, I implemented EventEmitter.defaultMaxListeners as proposed by node.js but idk if there is a prettier way of doing it for NestJS, feel free to change it.
- eslint fixes